### PR TITLE
refactor: centralize view routes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,19 +1,24 @@
-
 import { Routes } from '@angular/router';
-import { HomeComponent } from './components/views/home/home.component';
-import { NotFoundComponent } from './components/views/not-found/not-found.component';
+import { views } from './components/views/views.routes';
 
 export const routes: Routes = [
-    //pokemon
-     { path: 'Pokemon', loadChildren: () => import('./components/pokemon/pokemon.routes').then(m => m.pokemonroutes) },
-    //pokemonvs
-    { path: 'vs', loadChildren: () => import('./components/pokemonvs/pokemonvs.routes').then(m => m.pokemonvsroutes)},
-
-
-    //Homen
-    { path: 'home', component: HomeComponent },
-    { path: 'not-found', component: NotFoundComponent },
-    { path: '', redirectTo: '/home', pathMatch: 'full' },
-    { path: '**', redirectTo: 'not-found' }
-
+  //pokemon
+  {
+    path: 'Pokemon',
+    loadChildren: () =>
+      import('./components/pokemon/pokemon.routes').then(
+        (m) => m.pokemonroutes
+      ),
+  },
+  //pokemonvs
+  {
+    path: 'vs',
+    loadChildren: () =>
+      import('./components/pokemonvs/pokemonvs.routes').then(
+        (m) => m.pokemonvsroutes
+      ),
+  },
+  ...views,
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
+  { path: '**', redirectTo: 'not-found' },
 ];

--- a/src/app/components/views/views.routes.ts
+++ b/src/app/components/views/views.routes.ts
@@ -1,11 +1,15 @@
 import { Routes } from "@angular/router";
 import { HomeComponent } from "./home/home.component";
+import { NotFoundComponent } from "./not-found/not-found.component";
 
-
-export const views:Routes=[
-    {
-        path: 'Home',
-        component: HomeComponent
-      },
-    
-]
+export const views: Routes = [
+  {
+    path: 'home',
+    component: HomeComponent,
+  },
+  {
+    path: 'not-found',
+    component: NotFoundComponent,
+  },
+  // Additional view routes can be added here
+];


### PR DESCRIPTION
## Summary
- update view routes to use lowercase `home` and add a `not-found` page
- reuse `views.routes` in `app.routes` to keep routing paths consistent

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b67e002dec83219681b7b2f5411679