### PR TITLE
feat: add pokemon models and typings

### DIFF
--- a/src/app/components/pokemon/pokemon-list-detail/pokemon-list-detail.component.ts
+++ b/src/app/components/pokemon/pokemon-list-detail/pokemon-list-detail.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { PokemonService } from '../../../services/pokemon.service';
 import { CommonModule } from '@angular/common';
+import { PokemonDetail } from '../../../models/pokemon';
 
 @Component({
   selector: 'app-pokemon-list-detail',
@@ -11,7 +12,7 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./pokemon-list-detail.component.css']
 })
 export class PokemonListDetailComponent implements OnInit {
-  pokemon: any;
+  pokemon: PokemonDetail | null = null;
   loading = false;
 
   constructor(
@@ -28,7 +29,7 @@ export class PokemonListDetailComponent implements OnInit {
 
   fetchPokemonDetail(id: string): void {
     this.loading = true;
-    this.pokemonService.getPokemonDetail(id).subscribe(data => {
+    this.pokemonService.getPokemonDetail(id).subscribe((data: PokemonDetail) => {
       this.pokemon = data;
       this.loading = false;
     });

--- a/src/app/components/pokemon/pokemon-list/pokemon-list.component.ts
+++ b/src/app/components/pokemon/pokemon-list/pokemon-list.component.ts
@@ -3,6 +3,7 @@ import { PokemonService } from '../../../services/pokemon.service';
 import { CommonModule, TitleCasePipe } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterModule, Router } from '@angular/router';
+import { PokemonSummary, PokemonSummaryResponse } from '../../../models/pokemon';
 
 @Component({
   selector: 'app-pokemon-list',
@@ -12,7 +13,7 @@ import { RouterModule, Router } from '@angular/router';
   styleUrls: ['./pokemon-list.component.css']
 })
 export class PokemonListComponent implements OnInit {
-  pokemonList: any[] = [];
+  pokemonList: PokemonSummary[] = [];
   loading = false;
   offset = 0;
 
@@ -27,7 +28,7 @@ export class PokemonListComponent implements OnInit {
 
   fetchPokemonList(): void {
     this.loading = true;
-    this.pokemonService.getPokemonList(20, this.offset).subscribe(data => {
+    this.pokemonService.getPokemonList(20, this.offset).subscribe((data: PokemonSummaryResponse) => {
       this.pokemonList = data.results;
       this.loading = false;
     });
@@ -43,11 +44,11 @@ export class PokemonListComponent implements OnInit {
     return segments[segments.length - 2];
   }
 
-  verDetalle(pokemon: any): void {
-  const id = this.getIdFromUrl(pokemon.url);
-  console.log('Navegando a /detalle/' + id); // 👀 debug
-  this.router.navigate(['/Pokemon/detalle', id]); 
-}
+  verDetalle(pokemon: PokemonSummary): void {
+    const id = this.getIdFromUrl(pokemon.url);
+    console.log('Navegando a /detalle/' + id); // 👀 debug
+    this.router.navigate(['/Pokemon/detalle', id]);
+  }
 
 
 }

--- a/src/app/models/pokemon.ts
+++ b/src/app/models/pokemon.ts
@@ -1,0 +1,25 @@
+export interface PokemonSummary {
+  name: string;
+  url: string;
+}
+
+export interface PokemonSummaryResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: PokemonSummary[];
+}
+
+export interface PokemonDetail {
+  id: number;
+  name: string;
+  sprites: {
+    front_default: string;
+    [key: string]: any;
+  };
+  height: number;
+  weight: number;
+  types: Array<{ type: { name: string } }>;
+  abilities: Array<{ ability: { name: string } }>;
+  stats: Array<{ stat: { name: string }; base_stat: number }>;
+}

--- a/src/app/services/pokemon.service.ts
+++ b/src/app/services/pokemon.service.ts
@@ -2,6 +2,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiService } from './api.service';
+import { PokemonDetail, PokemonSummaryResponse } from '../models/pokemon';
 
 @Injectable({
   providedIn: 'root'
@@ -10,11 +11,11 @@ export class PokemonService {
 
   constructor(private api: ApiService) {}
 
-  getPokemonList(limit: number = 20, offset: number = 0): Observable<any> {
-    return this.api.get(`pokemon?limit=${limit}&offset=${offset}`);
+  getPokemonList(limit: number = 20, offset: number = 0): Observable<PokemonSummaryResponse> {
+    return this.api.get<PokemonSummaryResponse>(`pokemon?limit=${limit}&offset=${offset}`);
   }
 
-  getPokemonDetail(nameOrId: string | number): Observable<any> {
-    return this.api.get(`pokemon/${nameOrId}`);
+  getPokemonDetail(nameOrId: string | number): Observable<PokemonDetail> {
+    return this.api.get<PokemonDetail>(`pokemon/${nameOrId}`);
   }
 }


### PR DESCRIPTION
## Summary
- add PokemonSummary and PokemonDetail models
- type PokemonService and components with new interfaces

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b67fe92c4083219ccb969090670f78