### PR TITLE
refactor: parallelize pokemon detail requests

### DIFF
--- a/src/app/components/pokemonvs/pokemon-vs-preview/pokemon-vs-preview.component.ts
+++ b/src/app/components/pokemonvs/pokemon-vs-preview/pokemon-vs-preview.component.ts
@@ -1,13 +1,14 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { PokemonService } from '../../../services/pokemon.service';
 import { Router } from '@angular/router';
+import { Subscription, forkJoin, switchMap } from 'rxjs';
 
 @Component({
   selector: 'app-pokemon-vs-preview',
+  standalone: true,
   imports: [],
   templateUrl: './pokemon-vs-preview.component.html',
   styleUrls: ['./pokemon-vs-preview.component.css']
-
 })
 
 export class PokemonVsPreviewComponent implements OnInit, OnDestroy {
@@ -15,18 +16,32 @@ export class PokemonVsPreviewComponent implements OnInit, OnDestroy {
   leftIndex = 0;
   rightIndex = 1;
   intervalId: any;
+  private subscription?: Subscription;
 
   constructor(private pokemonService: PokemonService, private router: Router) {}
 
   ngOnInit(): void {
-    this.pokemonService.getPokemonList(20).subscribe(response => {
-      const results = response.results;
-      results.forEach((pokemon: any) => {
-        this.pokemonService.getPokemonDetail(pokemon.name).subscribe(detail => {
-          this.pokemonSprites.push(detail.sprites.front_default);
-        });
+    this.subscription = this.pokemonService
+      .getPokemonList(20)
+      .pipe(
+        switchMap((response) =>
+          forkJoin(
+            response.results.map((pokemon: any) =>
+              this.pokemonService.getPokemonDetail(pokemon.name)
+            )
+          )
+        )
+      )
+      .subscribe({
+        next: (details: any[]) => {
+          this.pokemonSprites = details.map(
+            (detail) => detail.sprites.front_default
+          );
+        },
+        error: (error) => {
+          console.error('Error fetching Pokémon details', error);
+        },
       });
-    });
 
     this.intervalId = setInterval(() => {
       this.leftIndex = (this.leftIndex + 1) % this.pokemonSprites.length;
@@ -36,6 +51,7 @@ export class PokemonVsPreviewComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     clearInterval(this.intervalId);
+    this.subscription?.unsubscribe();
   }
 
   goToVersus(): void {


### PR DESCRIPTION
## Summary
- use RxJS switchMap and forkJoin to load pokemon sprites concurrently
- manage subscription lifecycle and clean up on destroy
- mark pokemon vs preview component as standalone

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b6829e990c8321a31a18e9946e14de