### PR TITLE
feat: add search page module

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,6 +18,14 @@ export const routes: Routes = [
         (m) => m.pokemonvsroutes
       ),
   },
+  //search
+  {
+    path: 'search',
+    loadChildren: () =>
+      import('./components/search/search.routes').then(
+        (m) => m.searchroutes
+      ),
+  },
   ...views,
   { path: '', redirectTo: '/home', pathMatch: 'full' },
   { path: '**', redirectTo: 'not-found' },

--- a/src/app/components/search/search-filters/search-filters.component.css
+++ b/src/app/components/search/search-filters/search-filters.component.css
@@ -1,0 +1,3 @@
+.filters {
+  margin-top: 1rem;
+}

--- a/src/app/components/search/search-filters/search-filters.component.html
+++ b/src/app/components/search/search-filters/search-filters.component.html
@@ -1,0 +1,4 @@
+<!-- Filters for search can be added here -->
+<div class="filters">
+  <!-- Placeholder for future filter options -->
+</div>

--- a/src/app/components/search/search-filters/search-filters.component.ts
+++ b/src/app/components/search/search-filters/search-filters.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-search-filters',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './search-filters.component.html',
+  styleUrls: ['./search-filters.component.css']
+})
+export class SearchFiltersComponent {}
+

--- a/src/app/components/search/search-page/search-page.component.css
+++ b/src/app/components/search/search-page/search-page.component.css
@@ -1,0 +1,13 @@
+.search-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.result img {
+  max-width: 150px;
+}
+
+.error {
+  color: red;
+}

--- a/src/app/components/search/search-page/search-page.component.html
+++ b/src/app/components/search/search-page/search-page.component.html
@@ -1,0 +1,12 @@
+<form (ngSubmit)="onSubmit()" #searchForm="ngForm" class="search-form">
+  <input type="text" name="query" [(ngModel)]="query" placeholder="Nombre o ID" required />
+  <button type="submit">Buscar</button>
+</form>
+
+<app-search-filters></app-search-filters>
+
+<div *ngIf="result" class="result">
+  <h3>{{ result.name | titlecase }}</h3>
+  <img [src]="result.sprites?.front_default" [alt]="result.name" />
+</div>
+<div *ngIf="error" class="error">{{ error }}</div>

--- a/src/app/components/search/search-page/search-page.component.ts
+++ b/src/app/components/search/search-page/search-page.component.ts
@@ -1,0 +1,39 @@
+import { Component } from '@angular/core';
+import { CommonModule, TitleCasePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { PokemonService } from '../../../services/pokemon.service';
+import { SearchFiltersComponent } from '../search-filters/search-filters.component';
+
+@Component({
+  selector: 'app-search-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TitleCasePipe, SearchFiltersComponent],
+  templateUrl: './search-page.component.html',
+  styleUrls: ['./search-page.component.css']
+})
+export class SearchPageComponent {
+  query: string = '';
+  result: any;
+  error?: string;
+
+  constructor(private pokemonService: PokemonService) {}
+
+  onSubmit(): void {
+    if (!this.query) {
+      this.result = null;
+      return;
+    }
+
+    this.pokemonService.getPokemonDetail(this.query.toLowerCase()).subscribe({
+      next: (data) => {
+        this.result = data;
+        this.error = undefined;
+      },
+      error: () => {
+        this.result = null;
+        this.error = 'Pokémon no encontrado';
+      }
+    });
+  }
+}
+

--- a/src/app/components/search/search.routes.ts
+++ b/src/app/components/search/search.routes.ts
@@ -1,0 +1,6 @@
+import { Routes } from '@angular/router';
+import { SearchPageComponent } from './search-page/search-page.component';
+
+export const searchroutes: Routes = [
+  { path: 'search', component: SearchPageComponent }
+];


### PR DESCRIPTION
## Summary
- add standalone search page with filters component
- consume PokemonService in search form
- register search routes and lazy load

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: Building... interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c2d7b44c83218c948b6c88687dd9