### PR TITLE
feat: add filtered Pokemon search

### DIFF
--- a/src/app/components/search/search-filters/search-filters.component.html
+++ b/src/app/components/search/search-filters/search-filters.component.html
@@ -1,4 +1,18 @@
-<!-- Filters for search can be added here -->
 <div class="filters">
-  <!-- Placeholder for future filter options -->
+  <input
+    type="text"
+    name="type"
+    placeholder="Tipo"
+    [(ngModel)]="filters.type"
+    (ngModelChange)="onChange()"
+    [ngModelOptions]="{standalone: true}"
+  />
+  <input
+    type="text"
+    name="ability"
+    placeholder="Habilidad"
+    [(ngModel)]="filters.ability"
+    (ngModelChange)="onChange()"
+    [ngModelOptions]="{standalone: true}"
+  />
 </div>

--- a/src/app/components/search/search-filters/search-filters.component.ts
+++ b/src/app/components/search/search-filters/search-filters.component.ts
@@ -1,12 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-search-filters',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './search-filters.component.html',
   styleUrls: ['./search-filters.component.css']
 })
-export class SearchFiltersComponent {}
+export class SearchFiltersComponent {
+  @Output() filtersChange = new EventEmitter<{ type?: string; ability?: string }>();
+
+  filters: { type?: string; ability?: string } = {};
+
+  onChange(): void {
+    this.filtersChange.emit({
+      type: this.filters.type?.toLowerCase() || undefined,
+      ability: this.filters.ability?.toLowerCase() || undefined
+    });
+  }
+}
 

--- a/src/app/components/search/search-page/search-page.component.html
+++ b/src/app/components/search/search-page/search-page.component.html
@@ -1,12 +1,13 @@
 <form (ngSubmit)="onSubmit()" #searchForm="ngForm" class="search-form">
-  <input type="text" name="query" [(ngModel)]="query" placeholder="Nombre o ID" required />
+  <input type="text" name="query" [(ngModel)]="query" placeholder="Nombre" />
   <button type="submit">Buscar</button>
 </form>
 
-<app-search-filters></app-search-filters>
+<app-search-filters (filtersChange)="onFiltersChange($event)"></app-search-filters>
 
-<div *ngIf="result" class="result">
-  <h3>{{ result.name | titlecase }}</h3>
-  <img [src]="result.sprites?.front_default" [alt]="result.name" />
+<div *ngIf="results?.length" class="results">
+  <ul>
+    <li *ngFor="let p of results">{{ p.name | titlecase }}</li>
+  </ul>
 </div>
 <div *ngIf="error" class="error">{{ error }}</div>

--- a/src/app/components/search/search-page/search-page.component.ts
+++ b/src/app/components/search/search-page/search-page.component.ts
@@ -3,6 +3,7 @@ import { CommonModule, TitleCasePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PokemonService } from '../../../services/pokemon.service';
 import { SearchFiltersComponent } from '../search-filters/search-filters.component';
+import { PokemonSummary } from '../../../models/pokemon';
 
 @Component({
   selector: 'app-search-page',
@@ -13,27 +14,32 @@ import { SearchFiltersComponent } from '../search-filters/search-filters.compone
 })
 export class SearchPageComponent {
   query: string = '';
-  result: any;
+  filters: { type?: string; ability?: string } = {};
+  results: PokemonSummary[] | null = null;
   error?: string;
 
   constructor(private pokemonService: PokemonService) {}
 
-  onSubmit(): void {
-    if (!this.query) {
-      this.result = null;
-      return;
-    }
+  onFiltersChange(filters: { type?: string; ability?: string }): void {
+    this.filters = filters;
+  }
 
-    this.pokemonService.getPokemonDetail(this.query.toLowerCase()).subscribe({
+  onSubmit(): void {
+    const params = {
+      name: this.query ? this.query.toLowerCase() : undefined,
+      type: this.filters.type,
+      ability: this.filters.ability,
+    };
+
+    this.pokemonService.searchPokemon(params).subscribe({
       next: (data) => {
-        this.result = data;
-        this.error = undefined;
+        this.results = data.results;
+        this.error = data.results.length ? undefined : 'No se encontraron resultados';
       },
       error: () => {
-        this.result = null;
-        this.error = 'Pokémon no encontrado';
+        this.results = null;
+        this.error = 'Error en la búsqueda';
       }
     });
   }
 }
-

--- a/src/app/services/pokemon.service.ts
+++ b/src/app/services/pokemon.service.ts
@@ -3,13 +3,14 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiService } from './api.service';
 import { PokemonDetail, PokemonSummaryResponse } from '../models/pokemon';
+import { SearchService } from './search.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PokemonService {
 
-  constructor(private api: ApiService) {}
+  constructor(private api: ApiService, private search: SearchService) {}
 
   getPokemonList(limit: number = 20, offset: number = 0): Observable<PokemonSummaryResponse> {
     return this.api.get<PokemonSummaryResponse>(`pokemon?limit=${limit}&offset=${offset}`);
@@ -17,5 +18,9 @@ export class PokemonService {
 
   getPokemonDetail(nameOrId: string | number): Observable<PokemonDetail> {
     return this.api.get<PokemonDetail>(`pokemon/${nameOrId}`);
+  }
+
+  searchPokemon(params: { name?: string; type?: string; ability?: string }): Observable<PokemonSummaryResponse> {
+    return this.search.searchPokemon(params);
   }
 }

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { PokemonSummaryResponse } from '../models/pokemon';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SearchService {
+  constructor(private api: ApiService) {}
+
+  searchPokemon(params: { name?: string; type?: string; ability?: string }): Observable<PokemonSummaryResponse> {
+    const query = new URLSearchParams();
+    if (params.name) {
+      query.set('name', params.name);
+    }
+    if (params.type) {
+      query.set('type', params.type);
+    }
+    if (params.ability) {
+      query.set('ability', params.ability);
+    }
+    const endpoint = query.toString() ? `pokemon?${query.toString()}` : 'pokemon';
+    return this.api.get<PokemonSummaryResponse>(endpoint);
+  }
+}


### PR DESCRIPTION
## Summary
- add `SearchService` to query Pokémon with optional name, type, and ability filters
- expose `searchPokemon` via `PokemonService`
- wire up search filters in the UI and display list results

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c57c598c8321935fb08ead3af0ca